### PR TITLE
don't run ussdService when ussdController isn't

### DIFF
--- a/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDController.java
+++ b/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDController.java
@@ -42,6 +42,8 @@ public class USSDController implements USSDInterface{
 
     protected static final String KEY_ERROR = "KEY_ERROR";
 
+    protected Boolean isRunning = false;
+
     private USSDInterface ussdInterface;
 
     /**
@@ -98,6 +100,7 @@ public class USSDController implements USSDInterface{
             Uri uriPhone = Uri.parse("tel:" + ussdPhoneNumber);
             if (uriPhone != null)
                 context.startActivity(getActionCallIntent(uriPhone, simSlot));
+                isRunning = true;
         }
     }
 

--- a/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDController.java
+++ b/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDController.java
@@ -99,8 +99,8 @@ public class USSDController implements USSDInterface{
                 ussdPhoneNumber = ussdPhoneNumber.replace("#", uri);
             Uri uriPhone = Uri.parse("tel:" + ussdPhoneNumber);
             if (uriPhone != null)
-                context.startActivity(getActionCallIntent(uriPhone, simSlot));
                 isRunning = true;
+                context.startActivity(getActionCallIntent(uriPhone, simSlot));
         }
     }
 

--- a/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDService.java
+++ b/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDService.java
@@ -40,15 +40,18 @@ public class USSDService extends AccessibilityService {
                 event.getEventType(), event.getClassName(), event.getPackageName(),
                 event.getEventTime(), event.getText()));
 
+        if(!USSDController.instance.isRunning) { return; }
 
         if (LoginView(event) && notInputText(event)) {
             // first view or logView, do nothing, pass / FIRST MESSAGE
             clickOnButton(event, 0);
             USSDController.instance.callbackInvoke.over(event.getText().get(0).toString());
+            USSDController.instance.isRunning = false;
         }else if (problemView(event) || LoginView(event)) {
             // deal down
             clickOnButton(event, 1);
             USSDController.instance.callbackInvoke.over(event.getText().get(0).toString());
+            USSDController.instance.isRunning = false;
         }else if (isUSSDWidget(event)) {
             // ready for work
             String response = event.getText().get(0).toString();
@@ -60,6 +63,7 @@ public class USSDService extends AccessibilityService {
                 // sent 'OK' button
                 clickOnButton(event, 0);
                 USSDController.instance.callbackInvoke.over(response);
+                USSDController.instance.isRunning = false;
             } else {
                 // sent option 1
                 if (USSDController.instance.callbackMessage == null)

--- a/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDService.java
+++ b/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDService.java
@@ -45,13 +45,12 @@ public class USSDService extends AccessibilityService {
         if (LoginView(event) && notInputText(event)) {
             // first view or logView, do nothing, pass / FIRST MESSAGE
             clickOnButton(event, 0);
-            USSDController.instance.callbackInvoke.over(event.getText().get(0).toString());
             USSDController.instance.isRunning = false;
+            USSDController.instance.callbackInvoke.over(event.getText().get(0).toString());
         }else if (problemView(event) || LoginView(event)) {
             // deal down
             clickOnButton(event, 1);
             USSDController.instance.callbackInvoke.over(event.getText().get(0).toString());
-            USSDController.instance.isRunning = false;
         }else if (isUSSDWidget(event)) {
             // ready for work
             String response = event.getText().get(0).toString();
@@ -62,8 +61,8 @@ public class USSDService extends AccessibilityService {
                 // not more input panels / LAST MESSAGE
                 // sent 'OK' button
                 clickOnButton(event, 0);
-                USSDController.instance.callbackInvoke.over(response);
                 USSDController.instance.isRunning = false;
+                USSDController.instance.callbackInvoke.over(response);
             } else {
                 // sent option 1
                 if (USSDController.instance.callbackMessage == null)


### PR DESCRIPTION
currenty ussd cannot be used normally outside the app when voipUSSD accessability service is enabled. this commit adds a flag that is on when `callUSSDInvoke` is called and is off after `callbackInvoke.over` is called.