### PR TITLE
fix bug where app crashes when ussd is called

### DIFF
--- a/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDService.java
+++ b/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDService.java
@@ -40,7 +40,7 @@ public class USSDService extends AccessibilityService {
                 event.getEventType(), event.getClassName(), event.getPackageName(),
                 event.getEventTime(), event.getText()));
 
-        if(!USSDController.instance.isRunning) { return; }
+        if(USSDController.instance  == null || !USSDController.instance.isRunning) { return; }
 
         if (LoginView(event) && notInputText(event)) {
             // first view or logView, do nothing, pass / FIRST MESSAGE


### PR DESCRIPTION
When device or ussd service is restarted and user tries to dial ussd number, the application crashes because `USSDController` is not instantiated.
This commit prevent that by checking if `USSDController` is null first