### PR TITLE
Update USSDService.java

### DIFF
--- a/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDService.java
+++ b/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDService.java
@@ -155,6 +155,7 @@ public class USSDService extends AccessibilityService {
                 || event.getClassName().equals("com.android.phone.oppo.settings.LocalAlertDialog")
                 || event.getClassName().equals("com.zte.mifavor.widget.AlertDialog")
                 || event.getClassName().equals("color.support.v7.app.AlertDialog")
+                || event.getClassName().contains("AlertDialog")
                 || event.getClassName().equals("com.transsion.widgetslib.dialog.PromptDialog"));
     }
 


### PR DESCRIPTION
USSDService recognizing AlertDialog from multiples manufacturers libraries.
With the "contains" method, we are not mandatory to test each AlertDialog for each manufacturer while each of them use the same classname AlertDialog.