### PR TITLE
Generalize AlertDialog for any manufacturers API

### DIFF
--- a/ussd-library-kotlin/src/main/java/com/romellfudi/ussdlibrary/USSDServiceKT.java
+++ b/ussd-library-kotlin/src/main/java/com/romellfudi/ussdlibrary/USSDServiceKT.java
@@ -135,12 +135,7 @@ public class USSDServiceKT extends AccessibilityService {
      * @return boolean AccessibilityEvent is USSD
      */
     private boolean isUSSDWidget(AccessibilityEvent event) {
-        return (event.getClassName().equals("amigo.app.AmigoAlertDialog")
-                || event.getClassName().equals("android.app.AlertDialog")
-                || event.getClassName().equals("com.android.phone.oppo.settings.LocalAlertDialog")
-                || event.getClassName().equals("com.zte.mifavor.widget.AlertDialog")
-                || event.getClassName().equals("color.support.v7.app.AlertDialog")
-                || event.getClassName().equals("com.transsion.widgetslib.dialog.PromptDialog"));
+        return event.getClassName().toString().contains("AlertDialog");
     }
 
     /**

--- a/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDApi.java
+++ b/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDApi.java
@@ -26,4 +26,5 @@ public interface USSDApi {
                                USSDController.CallbackInvoke callbackInvoke);
     void callUSSDOverlayInvoke(String ussdPhoneNumber, int simSlot, HashMap<String,HashSet<String>> map,
                                USSDController.CallbackInvoke callbackInvoke);
+    boolean isCurrentlyWorking();
 }

--- a/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDController.java
+++ b/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDController.java
@@ -366,6 +366,6 @@ public class USSDController implements USSDInterface, USSDApi {
 
     @Override
     public boolean isCurrentlyWorking() {
-        return isRunning
+        return isRunning;
     }
 }

--- a/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDController.java
+++ b/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDController.java
@@ -48,7 +48,7 @@ public class USSDController implements USSDInterface, USSDApi {
 
     protected static final String KEY_ERROR = "KEY_ERROR";
 
-    protected Boolean isRunning = false;
+    public Boolean isRunning = false;
     protected Boolean send = false;
 
     private USSDInterface ussdInterface;

--- a/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDController.java
+++ b/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDController.java
@@ -48,7 +48,7 @@ public class USSDController implements USSDInterface, USSDApi {
 
     protected static final String KEY_ERROR = "KEY_ERROR";
 
-    public Boolean isRunning = false;
+    protected Boolean isRunning = false;
     protected Boolean send = false;
 
     private USSDInterface ussdInterface;
@@ -362,5 +362,10 @@ public class USSDController implements USSDInterface, USSDApi {
 
     public interface CallbackMessage {
         void responseMessage(String message);
+    }
+
+    @Override
+    public boolean isCurrentlyWorking() {
+        return isRunning
     }
 }

--- a/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDService.java
+++ b/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDService.java
@@ -150,13 +150,7 @@ public class USSDService extends AccessibilityService {
      * @return boolean AccessibilityEvent is USSD
      */
     private boolean isUSSDWidget(AccessibilityEvent event) {
-        return (event.getClassName().equals("amigo.app.AmigoAlertDialog")
-                || event.getClassName().equals("android.app.AlertDialog")
-                || event.getClassName().equals("com.android.phone.oppo.settings.LocalAlertDialog")
-                || event.getClassName().equals("com.zte.mifavor.widget.AlertDialog")
-                || event.getClassName().equals("color.support.v7.app.AlertDialog")
-                || event.getClassName().toString().contains("AlertDialog")
-                || event.getClassName().equals("com.transsion.widgetslib.dialog.PromptDialog"));
+        return event.getClassName().toString().contains("AlertDialog");
     }
 
     /**

--- a/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDService.java
+++ b/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDService.java
@@ -155,6 +155,7 @@ public class USSDService extends AccessibilityService {
                 || event.getClassName().equals("com.android.phone.oppo.settings.LocalAlertDialog")
                 || event.getClassName().equals("com.zte.mifavor.widget.AlertDialog")
                 || event.getClassName().equals("color.support.v7.app.AlertDialog")
+                || event.getClassName().toString().contains("AlertDialog")
                 || event.getClassName().equals("com.transsion.widgetslib.dialog.PromptDialog"));
     }
 


### PR DESCRIPTION
In order to avoid list one by one every AlertDialog from each manufacturer API, it should be possible to generalize by searching for the substring "AlertDialog". "PromptDialog" should also be added but for now, the "AlertDialog" class is used by many known manufacturers(Xiaomi, Samsung, oppo, Huawei...)