### PR TITLE
add support for old android ussd dialog (MTK based)

### DIFF
--- a/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDService.java
+++ b/ussd-library/src/main/java/com/romellfudi/ussdlibrary/USSDService.java
@@ -157,7 +157,8 @@ public class USSDService extends AccessibilityService {
                 || event.getClassName().equals("com.zte.mifavor.widget.AlertDialog")
                 || event.getClassName().equals("color.support.v7.app.AlertDialog")
                 || event.getClassName().equals("com.transsion.widgetslib.dialog.PromptDialog")
-                || event.getClassName().equals("miuix.appcompat.app.AlertDialog"));
+                || event.getClassName().equals("miuix.appcompat.app.AlertDialog")
+                || event.getClassName().equals("com.mediatek.phone.UssdAlertActivity"));
     }
 
     /**


### PR DESCRIPTION
some old android phone api 4.*  like lenovo A319 has dialog class as 
 com.mediatek.phone.UssdAlertActivity

all old MTK based versions of android have this type of dialog.